### PR TITLE
parameterize package management

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     'stdlib':
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.6.0'
   symlinks:
     logaggregation: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+---
+language: ruby
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" PARSER="future"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+sudo: false
+
+script: 'bundle exec bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,18 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
-gem 'puppet', puppetversion
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'metadata-json-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 0.3.2'
-gem 'facter', '>= 1.7.0', "< 1.8.0"
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,11 +3,42 @@
 # Module to manage the EIS Log Aggregation client
 #
 class logaggregation(
-  $package_name   = [ 'EISlogging', 'EISloggingNFS', ],
-  $package_ensure = 'installed',
+  $manage_packages = true,
+  $package_name    = 'USE_DEFAULTS',
+  $package_ensure  = 'installed',
 ) {
 
-  package { $package_name:
-    ensure => $package_ensure,
+  validate_bool($manage_packages)
+
+  if $manage_packages == true {
+
+    case $::osfamily {
+      'Debian': {
+        $package_name_default = [ 'eislogging', 'eisloggingnfs', ]
+      }
+      'RedHat': {
+        $package_name_default = [ 'EISlogging', 'EISloggingNFS', ]
+      }
+      'Suse': {
+        $package_name_default = [ 'EISlogging', 'EISloggingNFS', ]
+      }
+      default: {
+        fail("logaggregation support package management on osfamilies Debian, RedHat and Suse. Please set logaggregation::manage_packages to <false> for <${::osfamily}> hosts.")
+      }
+    }
+
+    if $package_name == 'USE_DEFAULTS' {
+      $package_name_real = $package_name_default
+    } else {
+      $package_name_real = any2array($package_name)
+    }
+
+    validate_array($package_name_real)
+
+    package { $package_name_real:
+      ensure => $package_ensure,
+    }
+
   }
+
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,7 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.before :each do
+    Puppet[:parser] = 'future' if ENV['PARSER'] == 'future'
+  end
+end


### PR DESCRIPTION
With this patch it is possible to deactivate package management for unsupported osfamilies.
With https://github.com/Phil-Friderici/puppet-module-logaggregation/pull/1 being merged, you could still use syslog message forwarding.
